### PR TITLE
Add image push to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: java
 services:
 - docker
 jdk: oraclejdk8
-script: mvn clean install
+script: mvn clean install -DskipDockerPush
+after_success:
+  - ./extras/travis_push_docker_hub.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: java
-services:
-- docker
+
+services: docker
+
 jdk: oraclejdk8
+install:
+  # installing dependencies and skipping docker push
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipDockerPush
+
+# We are skipping push here until after success
 script: mvn clean install -DskipDockerPush
+
 after_success:
   - ./extras/travis_push_docker_hub.sh
+
 cache:
   directories:
   - $HOME/.m2

--- a/ega-data-api-dataedge/pom.xml
+++ b/ega-data-api-dataedge/pom.xml
@@ -247,6 +247,7 @@
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
                             </imageTags>
                             <entryPoint>["java", "${debug.config}${debug.dataedge.port}", "-jar", "/${project.build.finalName}.jar"]
                             </entryPoint>
@@ -264,6 +265,13 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/ega-data-api-dataedge/pom.xml
+++ b/ega-data-api-dataedge/pom.xml
@@ -191,8 +191,12 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/dataedge:${image.version}</imageName>
+                            <imageName>${dockerRegistry}/dataedge</imageName>
                             <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
                             <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                             <resources>
                                 <resource>
@@ -208,6 +212,13 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -232,8 +243,11 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/dataedge:${image.version}</imageName>
+                            <imageName>${dockerRegistry}/dataedge</imageName>
                             <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                            </imageTags>
                             <entryPoint>["java", "${debug.config}${debug.dataedge.port}", "-jar", "/${project.build.finalName}.jar"]
                             </entryPoint>
                             <resources>

--- a/ega-data-api-filedatabase/pom.xml
+++ b/ega-data-api-filedatabase/pom.xml
@@ -230,6 +230,7 @@
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>
+								<imageTag>latest</imageTag>
 							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.filedatabase.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
@@ -246,6 +247,13 @@
 								<phase>package</phase>
 								<goals>
 									<goal>build</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>push-image</id>
+								<phase>package</phase>
+								<goals>
+									<goal>push</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/ega-data-api-filedatabase/pom.xml
+++ b/ega-data-api-filedatabase/pom.xml
@@ -175,8 +175,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/filedatabase:${image.version}</imageName>
-							<baseImage>java:8</baseImage>
+                            <imageName>${dockerRegistry}/filedatabase</imageName>
+                            <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -194,6 +198,13 @@
 									<goal>build</goal>
 								</goals>
 							</execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
 						</executions>
 					</plugin>
 				</plugins>
@@ -215,8 +226,11 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/filedatabase:${image.version}</imageName>
+							<imageName>${dockerRegistry}/filedatabase</imageName>
 							<baseImage>java:8</baseImage>
+							<imageTags>
+								<imageTag>${image.version}</imageTag>
+							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.filedatabase.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>

--- a/ega-data-api-key/pom.xml
+++ b/ega-data-api-key/pom.xml
@@ -267,11 +267,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-                            <imageName>${dockerRegistry}/key</imageName>
-                            <baseImage>java:8</baseImage>
-                            <imageTags>
-                                <imageTag>${image.version}</imageTag>
-                            </imageTags>
+							<imageName>${dockerRegistry}/key</imageName>
+							<baseImage>java:8</baseImage>
+							<imageTags>
+							    <imageTag>${image.version}</imageTag>
+							    <imageTag>latest</imageTag>
+							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.key.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -289,6 +290,13 @@
 									<goal>build</goal>
 								</goals>
 							</execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
 						</executions>
 					</plugin>
 				</plugins>

--- a/ega-data-api-key/pom.xml
+++ b/ega-data-api-key/pom.xml
@@ -216,8 +216,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/key:${image.version}</imageName>
+							<imageName>${dockerRegistry}/key</imageName>
 							<baseImage>java:8</baseImage>
+							<imageTags>
+								<imageTag>${image.version}</imageTag>
+								<imageTag>latest</imageTag>
+							</imageTags>
 							<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -235,6 +239,13 @@
 									<goal>build</goal>
 								</goals>
 							</execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
 						</executions>
 					</plugin>
 				</plugins>
@@ -256,8 +267,11 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/key:${image.version}</imageName>
-							<baseImage>java:8</baseImage>
+                            <imageName>${dockerRegistry}/key</imageName>
+                            <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "${debug.config}${debug.key.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>

--- a/ega-data-api-netflix/ega-data-api-config/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-config/pom.xml
@@ -118,9 +118,10 @@
 						<configuration>
 							<imageName>${dockerRegistry}/config</imageName>
 							<baseImage>java:8</baseImage>
-                            <imageTags>
-                                <imageTag>${image.version}</imageTag>
-                            </imageTags>
+							<imageTags>
+							    <imageTag>${image.version}</imageTag>
+							    <imageTag>latest</imageTag>
+							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.config.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -141,6 +142,13 @@
 								<phase>package</phase>
 								<goals>
 									<goal>build</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>push-image</id>
+								<phase>package</phase>
+								<goals>
+									<goal>push</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/ega-data-api-netflix/ega-data-api-config/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-config/pom.xml
@@ -60,8 +60,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/config:${image.version}</imageName>
-							<baseImage>java:8</baseImage>
+                            <imageName>${dockerRegistry}/config</imageName>
+                            <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -84,6 +88,13 @@
 									<goal>build</goal>
 								</goals>
 							</execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
 						</executions>
 					</plugin>
 				</plugins>
@@ -105,8 +116,11 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/config:${image.version}</imageName>
+							<imageName>${dockerRegistry}/config</imageName>
 							<baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "${debug.config}${debug.config.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>

--- a/ega-data-api-netflix/ega-data-api-eureka/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-eureka/pom.xml
@@ -140,11 +140,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-                            <imageName>${dockerRegistry}/eureka</imageName>
-                            <baseImage>java:8</baseImage>
-                            <imageTags>
-                                <imageTag>${image.version}</imageTag>
-                            </imageTags>
+							<imageName>${dockerRegistry}/eureka</imageName>
+							<baseImage>java:8</baseImage>
+							<imageTags>
+							    <imageTag>${image.version}</imageTag>
+							    <imageTag>latest</imageTag>
+							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.eureka.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -160,6 +161,13 @@
 								<phase>package</phase>
 								<goals>
 									<goal>build</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>push-image</id>
+								<phase>package</phase>
+								<goals>
+									<goal>push</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/ega-data-api-netflix/ega-data-api-eureka/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-eureka/pom.xml
@@ -89,8 +89,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/eureka:${image.version}</imageName>
+							<imageName>${dockerRegistry}/eureka</imageName>
 							<baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -108,6 +112,13 @@
 									<goal>build</goal>
 								</goals>
 							</execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
 						</executions>
 					</plugin>
 				</plugins>
@@ -129,8 +140,11 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/eureka:${image.version}</imageName>
-							<baseImage>java:8</baseImage>
+                            <imageName>${dockerRegistry}/eureka</imageName>
+                            <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                            </imageTags>
 							<entryPoint>["java", "${debug.config}${debug.eureka.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>

--- a/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
@@ -141,6 +141,7 @@
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>
+								<imageTag>latest</imageTag>
 							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.hystrix.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
@@ -157,6 +158,13 @@
 								<phase>package</phase>
 								<goals>
 									<goal>build</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>push-image</id>
+								<phase>package</phase>
+								<goals>
+									<goal>push</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
@@ -86,8 +86,12 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/hystrix:${image.version}</imageName>
+							<imageName>${dockerRegistry}/hystrix</imageName>
 							<baseImage>java:8</baseImage>
+							<imageTags>
+								<imageTag>${image.version}</imageTag>
+								<imageTag>latest</imageTag>
+							</imageTags>
 							<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>
@@ -103,6 +107,13 @@
 								<phase>package</phase>
 								<goals>
 									<goal>build</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>push-image</id>
+								<phase>package</phase>
+								<goals>
+									<goal>push</goal>
 								</goals>
 							</execution>
 						</executions>
@@ -126,8 +137,11 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/hystrix:${image.version}</imageName>
+							<imageName>${dockerRegistry}/hystrix</imageName>
 							<baseImage>java:8</baseImage>
+							<imageTags>
+								<imageTag>${image.version}</imageTag>
+							</imageTags>
 							<entryPoint>["java", "${debug.config}${debug.hystrix.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 							<resources>
 								<resource>

--- a/ega-data-api-res/pom.xml
+++ b/ega-data-api-res/pom.xml
@@ -293,6 +293,13 @@
                                     <goal>build</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/ega-data-api-res/pom.xml
+++ b/ega-data-api-res/pom.xml
@@ -218,8 +218,12 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/res:${image.version}</imageName>
+                            <imageName>${dockerRegistry}/res</imageName>
                             <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
                             <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                             <resources>
                                 <resource>
@@ -235,6 +239,13 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>push</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -259,8 +270,12 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/res:${image.version}</imageName>
+                            <imageName>${dockerRegistry}/res</imageName>
                             <baseImage>java:8</baseImage>
+                            <imageTags>
+                                <imageTag>${image.version}</imageTag>
+                                <imageTag>latest</imageTag>
+                            </imageTags>
                             <entryPoint>["java", "${debug.config}${debug.res.port}", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                             <resources>
                                 <resource>

--- a/extras/travis_push_docker_hub.sh
+++ b/extras/travis_push_docker_hub.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+DOCKER_REGISTRY=nbisweden
+
+OSS_MODULES=( ega-data-api-netflix/ega-data-api-config
+              ega-data-api-netflix/ega-data-api-eureka
+              ega-data-api-netflix/ega-data-api-hystrix )
+
+EGA_API_MODULES=( ega-data-api-dataedge
+                  ega-data-api-filedatabase
+                  ega-data-api-key
+                  ega-data-api-res )
+
+push_images () {
+    tag=$1
+    if [ "$2" == "oss" ]; then
+      maven_push "$tag" "${OSS_MODULES[@]}"
+    elif [ "$2" == "api" ]; then
+      maven_push "$tag" "${EGA_API_MODULES[@]}"
+    else
+      printf 'Option not recognized.'
+      exit 1
+    fi
+}
+
+maven_push () {
+  tag=$1
+  shift
+  modules=( "$@" )
+  for module in "${modules[@]}"; do
+    printf 'Pushing EGA-DATA-API image for module: %s\n' "$module with tag $tag"
+    mvn docker:push -pl "$module" -DdockerRegistry="${DOCKER_REGISTRY}" -DpushImageTag -DdokcerImageTags="$tag"
+  done
+}
+
+
+printf '%s\n' "$DOCKER_PASSWORD" |
+docker login -u "$DOCKER_USER" --password-stdin
+
+## Travis run on master branch and not a PR (this is after a PR has been approved)
+if  [ "$TRAVIS_BRANCH" = "master" ] &&
+    [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
+    push_images latest api
+    push_images latest oss
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<java.version>1.8</java.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<docker.maven.version>0.4.11</docker.maven.version>
+		<docker.maven.version>1.1.1</docker.maven.version>
 		<debug.config>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=</debug.config>
 		<debug.filedatabase.port>5050</debug.filedatabase.port>
 		<debug.dataedge.port>5059</debug.dataedge.port>
@@ -34,7 +34,7 @@
 		<debug.res.port>5090</debug.res.port>
 		<debug.key.port>5094</debug.key.port>
 		<image.version>v1</image.version>
-    	<dockerRegistry>ega-data-api</dockerRegistry>
+    <dockerRegistry>ega-data-api</dockerRegistry>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
As the title specifies, aiming to push image to docker hub.
Part of the changes:
* bumped `docker-maven-plugin` to `1.1.1` as it was missing some needed features;
* added push as part of execution (maybe there is a better way, I am open to suggestions);
* travis script that pushes images when there is a push on master;
* **still need service account to be added to travis-ci.org**.

Note: there is a 404 error on travis, not sure what causes it:
```
[WARNING] unable to get access token for Google Container Registry, configuration for building image will not contain RegistryAuth for GCR
java.io.IOException: Error code 404 trying to get security access token from Compute Engine metadata for the default service account. This may be because the virtual machine instance does not have permission scopes specified.
```