### PR TITLE
Adding new base registry and more identifiable image names

### DIFF
--- a/ega-data-api-dataedge/pom.xml
+++ b/ega-data-api-dataedge/pom.xml
@@ -191,7 +191,7 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/dataedge</imageName>
+                            <imageName>${dockerRegistry}/ega-dataedge</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
@@ -243,7 +243,7 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/dataedge</imageName>
+                            <imageName>${dockerRegistry}/ega-dataedge</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>

--- a/ega-data-api-filedatabase/pom.xml
+++ b/ega-data-api-filedatabase/pom.xml
@@ -175,7 +175,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-                            <imageName>${dockerRegistry}/filedatabase</imageName>
+                            <imageName>${dockerRegistry}/ega-filedatabase</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
@@ -226,7 +226,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/filedatabase</imageName>
+							<imageName>${dockerRegistry}/ega-filedatabase</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>

--- a/ega-data-api-key/pom.xml
+++ b/ega-data-api-key/pom.xml
@@ -216,7 +216,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/key</imageName>
+							<imageName>${dockerRegistry}/ega-keyserver</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>
@@ -267,7 +267,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/key</imageName>
+							<imageName>${dockerRegistry}/ega-keyserver</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 							    <imageTag>${image.version}</imageTag>

--- a/ega-data-api-netflix/ega-data-api-config/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-config/pom.xml
@@ -60,7 +60,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-                            <imageName>${dockerRegistry}/config</imageName>
+                            <imageName>${dockerRegistry}/netflix-config</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
@@ -116,7 +116,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/config</imageName>
+							<imageName>${dockerRegistry}/netflix-config</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 							    <imageTag>${image.version}</imageTag>

--- a/ega-data-api-netflix/ega-data-api-eureka/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-eureka/pom.xml
@@ -89,7 +89,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/eureka</imageName>
+							<imageName>${dockerRegistry}/netflix-eureka</imageName>
 							<baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
@@ -140,7 +140,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/eureka</imageName>
+							<imageName>${dockerRegistry}/netflix-eureka</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 							    <imageTag>${image.version}</imageTag>

--- a/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
+++ b/ega-data-api-netflix/ega-data-api-hystrix/pom.xml
@@ -86,7 +86,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/hystrix</imageName>
+							<imageName>${dockerRegistry}/netflix-hystrix</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>
@@ -137,7 +137,7 @@
 						<artifactId>docker-maven-plugin</artifactId>
 						<version>${docker.maven.version}</version>
 						<configuration>
-							<imageName>${dockerRegistry}/hystrix</imageName>
+							<imageName>${dockerRegistry}/netflix-hystrix</imageName>
 							<baseImage>java:8</baseImage>
 							<imageTags>
 								<imageTag>${image.version}</imageTag>

--- a/ega-data-api-res/pom.xml
+++ b/ega-data-api-res/pom.xml
@@ -218,7 +218,7 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/res</imageName>
+                            <imageName>${dockerRegistry}/ega-res</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>
@@ -270,7 +270,7 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>${docker.maven.version}</version>
                         <configuration>
-                            <imageName>${dockerRegistry}/res</imageName>
+                            <imageName>${dockerRegistry}/ega-res</imageName>
                             <baseImage>java:8</baseImage>
                             <imageTags>
                                 <imageTag>${image.version}</imageTag>

--- a/extras/travis_push_docker_hub.sh
+++ b/extras/travis_push_docker_hub.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-DOCKER_REGISTRY=nbisweden
-
 OSS_MODULES=( ega-data-api-netflix/ega-data-api-config
               ega-data-api-netflix/ega-data-api-eureka
               ega-data-api-netflix/ega-data-api-hystrix )


### PR DESCRIPTION
For the base Images we are planning to use as a Docker registry `cscfi` and this is set use the Travis Environments Variable.
Some image name changes we propose:
* for microservices: `${dockerRegistry}/ega-` + `service name` e,g `cscfi/ega-keyserver`;
* for Netflix OSS services: `${dockerRegistry}/netflix-` + Netflix component e.g. `cscfi/netflix-config`.