### PR TITLE
Fix typo for image push on master and don't install again on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ cache:
 
 script:
   # install and testing, withouth push
-  - mvn clean install -DskipDockerPush
+  # Do not build again on master
+  - if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+      mvn clean install -DskipDockerPush ;
+    fi
 after_success:
   # Push images, will be done only after push to master branch
   - ./extras/travis_push_docker_hub.sh

--- a/extras/travis_push_docker_hub.sh
+++ b/extras/travis_push_docker_hub.sh
@@ -26,8 +26,10 @@ maven_push () {
   shift
   modules=( "$@" )
   for module in "${modules[@]}"; do
+    printf 'Packaging EGA-Data-API'
+    mvn package -DskipTests -DskipDockerPush
     printf 'Pushing EGA-DATA-API image for module: %s\n' "$module with tag $tag"
-    mvn docker:build -pl "$module" -DdockerRegistry="${DOCKER_REGISTRY}" -DpushImageTag -DdokcerImageTags="$tag"
+    mvn docker:build -pl "$module" -DdockerRegistry="${DOCKER_REGISTRY}" -DpushImageTag -DdockerImageTags="$tag"
   done
 }
 


### PR DESCRIPTION
As mentioned in the title this fixes a typo in the travis script that pushed two tags instead of one and added the skip install on master branch, as it was taking too long