### PR TITLE
Adding api /file/{fileId}/key 

### DIFF
--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/DownloaderServiceApplication.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/DownloaderServiceApplication.java
@@ -15,24 +15,15 @@
  */
 package eu.elixir.ega.ebi.downloader;
 
-import com.google.common.cache.CacheBuilder;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.guava.GuavaCache;
-import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.cloud.client.loadbalancer.LoadBalanced;
-import org.springframework.context.annotation.Bean;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 @SpringBootApplication
 @EnableCaching
@@ -47,55 +38,6 @@ public class DownloaderServiceApplication extends SpringBootServletInitializer {
 
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
         return application.sources(DownloaderServiceApplication.class);
-    }
-
-    @LoadBalanced
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
-    }
-
-    @Bean
-    public CacheManager cacheManager() {
-        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
-        GuavaCache bySimpleFileId = new GuavaCache("bySimpleFileId", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache byFileId = new GuavaCache("byFileId", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache fileById = new GuavaCache("fileById", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache fileKeyById = new GuavaCache("fileKeyById", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache byFileKeyId = new GuavaCache("byFileKeyId", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache byFileIdCustom = new GuavaCache("byFileIdCustom", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache byFileIndexId = new GuavaCache("byFileIndexId", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache byDatasetId = new GuavaCache("byDatasetId", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache datasetByFile = new GuavaCache("datasetByFile", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache fileIndexFile = new GuavaCache("fileIndexFile", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-        GuavaCache datasetFiles = new GuavaCache("datasetFiles", CacheBuilder.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build());
-
-        simpleCacheManager.setCaches(Arrays.asList(bySimpleFileId, byFileId,
-                fileById, fileKeyById, byFileKeyId, byFileIdCustom, byFileIndexId, byDatasetId, datasetByFile, fileIndexFile,
-                datasetFiles));
-        return simpleCacheManager;
     }
 
 }

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/DownloaderServiceApplication.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/DownloaderServiceApplication.java
@@ -67,6 +67,12 @@ public class DownloaderServiceApplication extends SpringBootServletInitializer {
         GuavaCache fileById = new GuavaCache("fileById", CacheBuilder.newBuilder()
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .build());
+        GuavaCache fileKeyById = new GuavaCache("fileKeyById", CacheBuilder.newBuilder()
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .build());
+        GuavaCache byFileKeyId = new GuavaCache("byFileKeyId", CacheBuilder.newBuilder()
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .build());
         GuavaCache byFileIdCustom = new GuavaCache("byFileIdCustom", CacheBuilder.newBuilder()
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .build());
@@ -87,7 +93,7 @@ public class DownloaderServiceApplication extends SpringBootServletInitializer {
                 .build());
 
         simpleCacheManager.setCaches(Arrays.asList(bySimpleFileId, byFileId,
-                fileById, byFileIdCustom, byFileIndexId, byDatasetId, datasetByFile, fileIndexFile,
+                fileById, fileKeyById, byFileKeyId, byFileIdCustom, byFileIndexId, byDatasetId, datasetByFile, fileIndexFile,
                 datasetFiles));
         return simpleCacheManager;
     }

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/config/MyConfiguration.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/config/MyConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.downloader.config;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * @author amohan
+ */
+@Configuration
+@EnableCaching
+@EnableRetry
+@EnableEurekaClient
+public class MyConfiguration {
+
+    @Bean
+    @LoadBalanced
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        GuavaCache bySimpleFileId = new GuavaCache("bySimpleFileId",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache byFileId = new GuavaCache("byFileId",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache fileById = new GuavaCache("fileById",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache fileKeyById = new GuavaCache("fileKeyById",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache byFileKeyId = new GuavaCache("byFileKeyId",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache byFileIdCustom = new GuavaCache("byFileIdCustom",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache byFileIndexId = new GuavaCache("byFileIndexId",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache byDatasetId = new GuavaCache("byDatasetId",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache datasetByFile = new GuavaCache("datasetByFile",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache fileIndexFile = new GuavaCache("fileIndexFile",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+        GuavaCache datasetFiles = new GuavaCache("datasetFiles",
+                CacheBuilder.newBuilder().expireAfterWrite(24, TimeUnit.HOURS).build());
+
+        simpleCacheManager.setCaches(Arrays.asList(bySimpleFileId, byFileId, fileById, fileKeyById, byFileKeyId,
+                byFileIdCustom, byFileIndexId, byDatasetId, datasetByFile, fileIndexFile, datasetFiles));
+        return simpleCacheManager;
+    }
+
+}

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/domain/entity/FileKey.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/domain/entity/FileKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.downloader.domain.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author amohan
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Entity
+@Table(name = "file_key")
+public class FileKey implements Serializable {
+
+    @Id
+    @Size(max = 128)
+    @Column(name = "file_id", insertable = false, updatable = false, length = 128)
+    private String fileId;
+
+    @Column(name = "encryption_key_id", insertable = false, updatable = false)
+    private long encryptionKeyId;
+
+    @Size(max = 256)
+    @Column(name = "encryption_algorithm", insertable = false, updatable = false, length = 256)
+    private String encryptionAlgorithm;
+
+    @Override
+    public String toString() {
+        return "FileKey [fileId=" + fileId + ", encryptionKeyId=" + encryptionKeyId + ", encryptionAlgorithm="
+                + encryptionAlgorithm + "]";
+    }
+    
+    
+    
+}

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/domain/repository/FileKeyRepository.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/domain/repository/FileKeyRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.downloader.domain.repository;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
+
+/**
+ * @author amohan
+ */
+public interface FileKeyRepository extends CrudRepository<FileKey, String> {
+
+    @Cacheable(cacheNames = "byFileKeyId")
+    Iterable<FileKey> findByFileId(@Param("fileId") String fileId);
+    
+}

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/rest/FileController.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/rest/FileController.java
@@ -18,6 +18,7 @@ package eu.elixir.ega.ebi.downloader.rest;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.service.FileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class FileController {
     @ResponseBody
     public Iterable<File> get(@PathVariable String fileId) {
         return fileService.getFileByStableId(fileId);
+    }
+    
+    @RequestMapping(value = "/{fileId}/key", method = GET)
+    @ResponseBody
+    public Iterable<FileKey> getKey(@PathVariable String fileId) {
+        return fileService.getKeyIdByFileId(fileId);
     }
 
     @RequestMapping(value = "/{fileId}/datasets", method = GET)

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/FileService.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/FileService.java
@@ -18,6 +18,7 @@ package eu.elixir.ega.ebi.downloader.service;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.dto.DownloaderFile;
 
 /**
@@ -26,6 +27,8 @@ import eu.elixir.ega.ebi.downloader.dto.DownloaderFile;
 public interface FileService {
 
     Iterable<File> getFileByStableId(String fileIDs);
+    
+    Iterable<FileKey> getKeyIdByFileId(String fileID);
 
     Iterable<FileDataset> getFileDatasetByFileId(String fileID);
 

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/internal/FileServiceImpl.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/internal/FileServiceImpl.java
@@ -19,11 +19,14 @@ import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileDatasetRepository;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileIndexFileRepository;
+import eu.elixir.ega.ebi.downloader.domain.repository.FileKeyRepository;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileRepository;
 import eu.elixir.ega.ebi.downloader.dto.DownloaderFile;
 import eu.elixir.ega.ebi.downloader.service.FileService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -49,12 +52,22 @@ public class FileServiceImpl implements FileService {
 
     @Autowired
     private FileIndexFileRepository fileIndexFileRepository;
+    
+    @Autowired
+    private FileKeyRepository fileKeyRepository;
 
     @Override
     @Cacheable(cacheNames = "fileById")
     @HystrixCommand
     public Iterable<File> getFileByStableId(String fileIds) {
         return fileRepository.findByFileId(fileIds);
+    }
+    
+    @Override
+    @Cacheable(cacheNames = "fileKeyById")
+    @HystrixCommand
+    public Iterable<FileKey> getKeyIdByFileId(String fileID) {
+        return fileKeyRepository.findByFileId(fileID);
     }
 
     @Override

--- a/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/internal/LocalEGAFileServiceImpl.java
+++ b/ega-data-api-filedatabase/src/main/java/eu/elixir/ega/ebi/downloader/service/internal/LocalEGAFileServiceImpl.java
@@ -20,6 +20,7 @@ import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.dto.DownloaderFile;
 import eu.elixir.ega.ebi.downloader.service.FileService;
 import lombok.extern.slf4j.Slf4j;
@@ -101,6 +102,11 @@ public class LocalEGAFileServiceImpl implements FileService {
     @Autowired
     public void setRestTemplate(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public Iterable<FileKey> getKeyIdByFileId(String fileID) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
 }

--- a/ega-data-api-filedatabase/src/main/resources/FileKey.sql
+++ b/ega-data-api-filedatabase/src/main/resources/FileKey.sql
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 ELIXIR EGA
+/* 
+ * Copyright 2017 ELIXIR EGA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.elixir.ega.ebi.keyproviderservice.domain.repository;
-
-import eu.elixir.ega.ebi.keyproviderservice.domain.entity.EncryptionKey;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
-
 /**
- * @author asenf
+ * Author:  asenf
+ * Created: 17-Feb-2017
  */
-public interface EncryptionKeyRepository extends CrudRepository<EncryptionKey, Long> {
 
-    @Cacheable(cacheNames = "byId")
-    EncryptionKey findById(@Param("id") Long id);
-
-}
+CREATE TABLE dev_ega_file.file_key (
+	file_id  varchar(128) NULL,
+	encryption_key_id int8 NULL,
+    encryption_algorithm varchar(128) NULL
+)
+WITH (
+	OIDS=FALSE
+);

--- a/ega-data-api-filedatabase/src/test/java/eu/elixir/ega/ebi/downloader/rest/FileControllerTest.java
+++ b/ega-data-api-filedatabase/src/test/java/eu/elixir/ega/ebi/downloader/rest/FileControllerTest.java
@@ -40,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.service.FileService;
 
 /**
@@ -67,13 +68,26 @@ public class FileControllerTest {
 	@Test
 	public void testGet() throws Exception {
 		final List<File> files = new ArrayList<>();
-		final File file = new File();
-		file.setFileId("fileId");
-
+				
 		when(fileService.getFileByStableId(any(String.class))).thenReturn(files);
 		final MockHttpServletResponse response = mockMvc.perform(get("/file/fileId").accept(APPLICATION_JSON)).andReturn().getResponse();
 		assertThat(response.getStatus(), equalTo(OK.value()));
 	}
+
+	   /**
+     * Test {@link FileController#getKey(String)}. Verify the api call returns
+     * status is OK.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testGetKey() throws Exception {
+        final List<FileKey> files = new ArrayList<>();
+        
+        when(fileService.getKeyIdByFileId(any(String.class))).thenReturn(files);
+        final MockHttpServletResponse response = mockMvc.perform(get("/file/fileId/key").accept(APPLICATION_JSON)).andReturn().getResponse();
+        assertThat(response.getStatus(), equalTo(OK.value()));
+    }
 
 	/**
 	 * Test {@link FileController#getDatasets(String)}. Verify the api call
@@ -84,9 +98,7 @@ public class FileControllerTest {
 	@Test
 	public void testGetDatasets() throws Exception {
 		final List<FileDataset> fileDatasets = new ArrayList<>();
-		final FileDataset fileDataset = new FileDataset();
-		fileDataset.setFileId("fileId");
-
+		
 		when(fileService.getFileDatasetByFileId(any(String.class))).thenReturn(fileDatasets);
 		final MockHttpServletResponse response = mockMvc
 				.perform(get("/file/file_id/datasets").accept(APPLICATION_JSON)).andReturn().getResponse();
@@ -102,9 +114,7 @@ public class FileControllerTest {
 	@Test
 	public void testGetIndex() throws Exception {
 		final List<FileIndexFile> fileIndexFiles = new ArrayList<>();
-		final FileIndexFile fileIndexFile = new FileIndexFile();
-		fileIndexFile.setFileId("fileId");
-
+		
 		when(fileService.getFileIndexByFileId(any(String.class))).thenReturn(fileIndexFiles);
 		final MockHttpServletResponse response = mockMvc.perform(get("/file/fileId/index").accept(APPLICATION_JSON))
 				.andReturn().getResponse();

--- a/ega-data-api-filedatabase/src/test/java/eu/elixir/ega/ebi/downloader/service/internal/FileServiceImplTest.java
+++ b/ega-data-api-filedatabase/src/test/java/eu/elixir/ega/ebi/downloader/service/internal/FileServiceImplTest.java
@@ -35,8 +35,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 import eu.elixir.ega.ebi.downloader.domain.entity.File;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileDataset;
 import eu.elixir.ega.ebi.downloader.domain.entity.FileIndexFile;
+import eu.elixir.ega.ebi.downloader.domain.entity.FileKey;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileDatasetRepository;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileIndexFileRepository;
+import eu.elixir.ega.ebi.downloader.domain.repository.FileKeyRepository;
 import eu.elixir.ega.ebi.downloader.domain.repository.FileRepository;
 import java.util.Iterator;
 
@@ -59,10 +61,14 @@ public class FileServiceImplTest {
 
 	@MockBean
 	private FileIndexFileRepository fileIndexFileRepository;
+	
+	@MockBean
+    private FileKeyRepository fileKeyRepository;
 
 	@Before
 	public void setup() {
 		when(fileRepository.findByFileId(any(String.class))).thenReturn(getFile());
+		when(fileKeyRepository.findByFileId(any(String.class))).thenReturn(getFileKey());
 		when(fileDatasetRepository.findByFileId(any(String.class))).thenReturn(getFileDataset());
 		when(fileDatasetRepository.findByDatasetId(any(String.class))).thenReturn(getFileDataset());
 		when(fileIndexFileRepository.findByFileId(any(String.class))).thenReturn(getFileIndexFile());
@@ -77,6 +83,16 @@ public class FileServiceImplTest {
 		assertThat(fileServiceImpl.getFileByStableId("fileId").iterator().next().getFileId(), equalTo(getFile()
 				.iterator().next().getFileId()));
 	}
+	
+    /**
+     * Test class for {@link FileServiceImpl#getKeyIdByFileId(String)}. Verify
+     * fileId retrieved from db mock call.
+     */
+    @Test
+    public void testGetKeyIdByFileId() {
+        assertThat(fileServiceImpl.getKeyIdByFileId("fileId").iterator().next().getFileId(), equalTo(getFileKey()
+                .iterator().next().getFileId()));
+    }
 
 	/**
 	 * Test class for {@link FileServiceImpl#getFileDatasetByFileId(String)}.
@@ -114,6 +130,14 @@ public class FileServiceImplTest {
 		file.setFileId("fileId");
 		return Arrays.asList(file);
 	}
+	
+	private Iterable<FileKey> getFileKey() {
+        final FileKey fileKey = new FileKey();
+        fileKey.setEncryptionAlgorithm("encryptionAlgorithm");
+        fileKey.setEncryptionKeyId(1);
+        fileKey.setFileId("fileId");
+        return Arrays.asList(fileKey);
+    }
 
 	private Iterable<FileDataset> getFileDataset() {
 		return Arrays.asList(new FileDataset("fileId", "datasetId"));

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/CustomAutoconfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/CustomAutoconfiguration.java
@@ -1,0 +1,30 @@
+package eu.elixir.ega.ebi.keyproviderservice;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class CustomAutoconfiguration {
+
+  @Profile("db")
+  @Configuration
+  @EnableAutoConfiguration
+  public class DbAutoconfiguration {
+
+  }
+
+  @Profile("!db")
+  @Configuration
+  @EnableAutoConfiguration(exclude = {
+      DataSourceAutoConfiguration.class,
+      DataSourceTransactionManagerAutoConfiguration.class,
+      HibernateJpaAutoConfiguration.class})
+  public class NoDbAutoconfiguration {
+
+  }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/CustomAutoconfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/CustomAutoconfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.elixir.ega.ebi.keyproviderservice;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
@@ -29,15 +29,18 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-@SpringBootApplication
+@Configuration
+@ComponentScan
 @EnableCaching
 @EnableHystrix
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
 @EnableSwagger2
 @EnableDiscoveryClient
 @EnableHystrixDashboard

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
@@ -30,7 +30,6 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @ComponentScan
 @EnableCaching
 @EnableHystrix
-@EnableSwagger2
 @EnableDiscoveryClient
 @EnableHystrixDashboard
 public class KeyProviderServiceApplication {

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
@@ -15,27 +15,16 @@
  */
 package eu.elixir.ega.ebi.keyproviderservice;
 
-import com.google.common.cache.CacheBuilder;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.guava.GuavaCache;
-import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @ComponentScan
@@ -50,15 +39,6 @@ public class KeyProviderServiceApplication {
         SpringApplication.run(KeyProviderServiceApplication.class, args);
     }
 
-    @Bean
-    public CacheManager cacheManager() {
-        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
-        GuavaCache byFileId = new GuavaCache("byId", CacheBuilder.newBuilder()
-                .expireAfterAccess(24, TimeUnit.HOURS)
-                .build());
-
-        simpleCacheManager.setCaches(Collections.singletonList(byFileId));
-        return simpleCacheManager;
-    }
+    
 
 }

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/CustomAutoconfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/CustomAutoconfiguration.java
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.elixir.ega.ebi.keyproviderservice;
+package eu.elixir.ega.ebi.keyproviderservice.config;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
 public class CustomAutoconfiguration {
@@ -28,6 +30,8 @@ public class CustomAutoconfiguration {
   @Profile("db")
   @Configuration
   @EnableAutoConfiguration
+  @EntityScan(basePackages = "eu.elixir.ega.ebi.keyproviderservice.domain.entity" )
+  @EnableJpaRepositories(basePackages = "eu.elixir.ega.ebi.keyproviderservice.domain.repository" )
   public class DbAutoconfiguration {
 
   }

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/MyConfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/MyConfiguration.java
@@ -15,15 +15,29 @@
  */
 package eu.elixir.ega.ebi.keyproviderservice.config;
 
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestTemplate;
+
+import com.google.common.cache.CacheBuilder;
 
 /**
  * @author asenf
  */
 @Configuration
+@EnableCaching
+@EnableRetry
+@EnableEurekaClient
 public class MyConfiguration {
 
     @Value("${ega.key.path}")
@@ -51,4 +65,14 @@ public class MyConfiguration {
         return new RestTemplate();
     }
 
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        GuavaCache byFileId = new GuavaCache("byId", CacheBuilder.newBuilder()
+                .expireAfterAccess(24, TimeUnit.HOURS)
+                .build());
+
+        simpleCacheManager.setCaches(Collections.singletonList(byFileId));
+        return simpleCacheManager;
+    }
 }

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/entity/EncryptionKey.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/entity/EncryptionKey.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 @Setter
 @Getter
 @Entity
+@Table(name = "encryption_key")
 public class EncryptionKey implements Serializable {
 
     @Id

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
@@ -49,7 +49,7 @@ public class KeyServiceImpl implements KeyService {
     @HystrixCommand
     @ResponseBody
     public String getFileKey(String id) {
-        EncryptionKey findById = encryptionKeyRepository.findById(id);
+        EncryptionKey findById = encryptionKeyRepository.findById(Long.parseLong(id));
         return findById.getEncryptionKey();
     }
 

--- a/ega-data-api-key/src/main/resources/EncryptionKey.sql
+++ b/ega-data-api-key/src/main/resources/EncryptionKey.sql
@@ -19,7 +19,7 @@
  */
 
 CREATE TABLE encryption_key (
-	encryption_key_id bigserial NOT NULL,
+	encryption_key_id int8 NOT NULL,
 	alias varchar(128) NOT NULL,
-	encryption_key text NOT NULL,
+	encryption_key text NOT NULL
 ) ;

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/SampleTestConfiguration.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/SampleTestConfiguration.java
@@ -1,0 +1,8 @@
+package eu.elixir.ega.ebi.keyproviderservice;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleTestConfiguration {
+
+}

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
@@ -50,7 +50,6 @@ import eu.elixir.ega.ebi.keyproviderservice.service.KeyService;
 @TestPropertySource(locations = "classpath:application-test.properties")
 public final class KeyServiceImplTest {
 
-    private final String ID = "1";
     private final long KEY_ID = 1000l;
     private final String ENCRYPTION_KEY = "encryptionKey";
     private final String PUBLIC_KEY = "publicKey";
@@ -72,9 +71,9 @@ public final class KeyServiceImplTest {
      */
     @Test
     public void testGetFileKey() {
-        final EncryptionKey fileKey = new EncryptionKey(100l, "alias", ENCRYPTION_KEY);
-        when(encryptionKeyRepository.findById(Long.parseLong(ID))).thenReturn(fileKey);
-        assertThat(keyService.getFileKey(ID), equalTo(ENCRYPTION_KEY));
+        final EncryptionKey fileKey = new EncryptionKey(KEY_ID, "alias", ENCRYPTION_KEY);
+        when(encryptionKeyRepository.findById(KEY_ID)).thenReturn(fileKey);
+        assertThat(keyService.getFileKey(Long.toString(KEY_ID)), equalTo(ENCRYPTION_KEY));
     }
 
     /**

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
@@ -50,7 +50,7 @@ import eu.elixir.ega.ebi.keyproviderservice.service.KeyService;
 @TestPropertySource(locations = "classpath:application-test.properties")
 public final class KeyServiceImplTest {
 
-    private final String ID = "id";
+    private final String ID = "1";
     private final long KEY_ID = 1000l;
     private final String ENCRYPTION_KEY = "encryptionKey";
     private final String PUBLIC_KEY = "publicKey";
@@ -73,7 +73,7 @@ public final class KeyServiceImplTest {
     @Test
     public void testGetFileKey() {
         final EncryptionKey fileKey = new EncryptionKey(100l, "alias", ENCRYPTION_KEY);
-        when(encryptionKeyRepository.findById(ID)).thenReturn(fileKey);
+        when(encryptionKeyRepository.findById(Long.parseLong(ID))).thenReturn(fileKey);
         assertThat(keyService.getFileKey(ID), equalTo(ENCRYPTION_KEY));
     }
 

--- a/ega-data-api-netflix/ega-data-api-config/config-files/keyserver.properties
+++ b/ega-data-api-netflix/ega-data-api-config/config-files/keyserver.properties
@@ -2,6 +2,8 @@ spring.application.name= keyserver
 
 server.port = 9095
 
+spring.profiles.active=db
+
 #deprecated
 ega.ebi.cipherConfig = /homes/ega-prod/ngs_3/config/DecryptionEcosystem.xml
 ega.key.path=

--- a/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/MyConfiguration.java
+++ b/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/MyConfiguration.java
@@ -72,6 +72,9 @@ public class MyConfiguration {
 
     @Autowired
     private LoadBalancerClient loadBalancer;
+    
+    @Autowired
+    private Cache<String, EgaAESFileHeader> myCache;
 
     @LoadBalanced
     @Bean
@@ -103,7 +106,8 @@ public class MyConfiguration {
     public Cache<String, CachePage> myPageCache() throws Exception {
         int pagesize = 1024 * 1024 * 12;    // 12 MB Page Size
         int pageCount = 1200;               // 1200 * 12 = 14 GB Cache Size
-        return (new My2KCachePageFactory(loadBalancer,
+        return (new My2KCachePageFactory(myCache,
+                loadBalancer,
                 pagesize,
                 pageCount,
                 awsKey,

--- a/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/dto/FileKey.java
+++ b/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/dto/FileKey.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.reencryptionmvc.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author amohan
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+public class FileKey {
+
+    private String fileId;
+    private String encryptionKeyId;
+    private String encryptionAlgorithm;
+
+}

--- a/ega-data-api-res/src/test/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/CleversaveArchiveServiceImplTest.java
+++ b/ega-data-api-res/src/test/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/CleversaveArchiveServiceImplTest.java
@@ -39,6 +39,7 @@ import org.springframework.web.client.RestTemplate;
 
 import eu.elixir.ega.ebi.reencryptionmvc.dto.ArchiveSource;
 import eu.elixir.ega.ebi.reencryptionmvc.dto.EgaFile;
+import eu.elixir.ega.ebi.reencryptionmvc.dto.FileKey;
 import eu.elixir.ega.ebi.reencryptionmvc.service.ArchiveAdapterService;
 import eu.elixir.ega.ebi.reencryptionmvc.service.KeyService;
 
@@ -76,8 +77,11 @@ public class CleversaveArchiveServiceImplTest {
     @Test
     public void testGetArchiveFile() {
         final ResponseEntity<EgaFile[]> mockResponseEntity = mock(ResponseEntity.class);
+        final ResponseEntity<FileKey[]> mockResponseFileKeyEntity = mock(ResponseEntity.class);
         final EgaFile[] body = new EgaFile[1];
         body[0] = new EgaFile("fileId0", "/fire/0000TR.CEL.gpg", null, 100, "fileStatus0", null);
+        final FileKey[] filekey = new FileKey[1];
+        filekey[0] = new FileKey("fileId0", "encryptionKeyId", "encryptionAlgorithm");
 
         final String pathInput = "/EGAZ00001257562/analysis/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.cip";
         final String object_get = "http://egaread:8oAgZc0DH6dR@10.32.25.44/ega/06ca84a54eeadf8acd3cf05691652d5e0014";
@@ -88,8 +92,12 @@ public class CleversaveArchiveServiceImplTest {
         final String[] filePath = { object_get, object_length, object_storage_class, pathInput };
         when(restTemplate.getForEntity(FILEDATABASE_SERVICE + "/file/{fileId}", EgaFile[].class, "id"))
                 .thenReturn(mockResponseEntity);
+        when(restTemplate.getForEntity(FILEDATABASE_SERVICE + "/file/{fileId}/key", FileKey[].class, "id"))
+        .thenReturn(mockResponseFileKeyEntity);
         when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
         when(mockResponseEntity.getBody()).thenReturn(body);
+        when(mockResponseFileKeyEntity.getBody()).thenReturn(filekey);
+
         when(archiveAdapterService.getPath(anyString())).thenReturn(filePath);
         when(keyService.getFileKey(anyString())).thenReturn(encryptionKey);
 


### PR DESCRIPTION
The previous process was to get the encryption key value from the file.
Now the encryption key is stored on the database but in a different schema, for instance, file_key_test
and all the file related metadata is stored in a different schema, dev_ega_file.
 
