### PR TITLE
 Adding logic to decrypt the db key using aes and decryptpassword.

### DIFF
--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/KeyProviderServiceApplication.java
@@ -15,47 +15,24 @@
  */
 package eu.elixir.ega.ebi.keyproviderservice;
 
-import com.google.common.cache.CacheBuilder;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.guava.GuavaCache;
-import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
-import org.springframework.context.annotation.Bean;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-
-@SpringBootApplication
+@Configuration
+@ComponentScan
 @EnableCaching
 @EnableHystrix
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
-@EnableSwagger2
 @EnableDiscoveryClient
 @EnableHystrixDashboard
 public class KeyProviderServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(KeyProviderServiceApplication.class, args);
-    }
-
-    @Bean
-    public CacheManager cacheManager() {
-        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
-        GuavaCache byFileId = new GuavaCache("byId", CacheBuilder.newBuilder()
-                .expireAfterAccess(24, TimeUnit.HOURS)
-                .build());
-
-        simpleCacheManager.setCaches(Collections.singletonList(byFileId));
-        return simpleCacheManager;
     }
 
 }

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/AesCtr256Ega.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/AesCtr256Ega.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import org.bouncycastle.util.io.Streams;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Provides functionality to encrypt files using Alexander's AES flavour.
+ */
+
+@Component
+public class AesCtr256Ega extends JdkEncryptionAlgorithm {
+    private static final int ITERATION_COUNT = 1024;
+
+    private static int KEY_SIZE = 256;
+
+    private static byte[] DEFAULT_SALT = new byte[]{-12, 34, 1, 0, -98, -33, 78, 21};
+
+    private IvParameterSpec ivParameterSpec;
+
+    private SecretKey secretKey;
+
+    @Override
+    protected void initializeRead(InputStream inputStream, char[] password) throws IOException {
+        byte[] IV = new byte[16];
+        Streams.readFully(inputStream, IV);
+        ivParameterSpec = new IvParameterSpec(IV);
+        secretKey = getKey(password, DEFAULT_SALT);
+    }
+
+    @Override
+    protected void initializeWrite(char[] password, OutputStream outputStream) throws IOException {
+        byte[] randomBytes = new byte[16];
+        Random.getSHA1PRNG().nextBytes(randomBytes);
+        outputStream.write(randomBytes);
+        ivParameterSpec = new IvParameterSpec(randomBytes);
+        secretKey = getKey(password, DEFAULT_SALT);
+    }
+
+    @Override
+    protected Cipher getCipher(int encryptMode) {
+        return Encryption.getCipher("AES/CTR/NoPadding", encryptMode, secretKey, ivParameterSpec);
+    }
+
+    public static SecretKeySpec getKey(char[] password, byte[] salt) {
+        PBEKeySpec pBEKeySpec = new PBEKeySpec(password, salt, ITERATION_COUNT, KEY_SIZE);
+        return new SecretKeySpec(Encryption.getSecretKey("PBKDF2WithHmacSHA1", pBEKeySpec).getEncoded(), "AES");
+    }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/Encryption.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/Encryption.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+public class Encryption {
+
+    private final static Logger logger = LoggerFactory.getLogger(Encryption.class);
+
+    /**
+     * Returns configured cipher following the specification provided. This method is only recommended for known
+     * working specifications.
+     *
+     * @param algorithm
+     * @param encryptMode
+     * @param secretKey
+     * @param ivParameterSpec
+     * @return Cipher
+     * @throws AssertionError if specification is invalid or algorithm could not be found
+     */
+    public static Cipher getCipher(String algorithm, int encryptMode, SecretKey secretKey,
+                                   IvParameterSpec ivParameterSpec) {
+        try {
+            Cipher cipher = Cipher.getInstance(algorithm);
+            cipher.init(encryptMode, secretKey, ivParameterSpec);
+            return cipher;
+        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException | NoSuchAlgorithmException |
+                InvalidKeyException e) {
+            logger.error(e.getMessage(), e);
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Returns a secret key according algorithm and key specifications. This method is only recommended for known
+     * working algorithm/specification pairs
+     * @param algorithm
+     * @param keySpec
+     * @return
+     * @throws AssertionError if algorithm could not be instanced or specification is not valid.
+     */
+    public static SecretKey getSecretKey(String algorithm, KeySpec keySpec) {
+        try {
+            return SecretKeyFactory.getInstance(algorithm).generateSecret(keySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            logger.error(e.getMessage(), e);
+            throw new AssertionError(e);
+        }
+    }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/EncryptionAlgorithm.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/EncryptionAlgorithm.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface EncryptionAlgorithm {
+
+    OutputStream encrypt(char[] password, OutputStream outputStream) throws IOException;
+
+    InputStream decrypt(InputStream inputStream, char[] password) throws IOException;
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/JdkEncryptionAlgorithm.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/JdkEncryptionAlgorithm.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public abstract class JdkEncryptionAlgorithm implements EncryptionAlgorithm{
+
+    @Override
+    public OutputStream encrypt(char[] password, OutputStream outputStream) throws IOException {
+        initializeWrite(password, outputStream);
+        return new CipherOutputStream(outputStream, getCipher(Cipher.ENCRYPT_MODE));
+    }
+
+    @Override
+    public InputStream decrypt(InputStream inputStream, char[] password) throws IOException {
+        initializeRead(inputStream, password);
+        return new CipherInputStream(inputStream, getCipher(Cipher.DECRYPT_MODE));
+    }
+
+    protected abstract void initializeRead(InputStream inputStream, char[] password) throws IOException;
+
+    protected abstract void initializeWrite(char[] password, OutputStream outputStream) throws IOException;
+
+    protected abstract Cipher getCipher(int encryptMode);
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/Random.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/Random.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Random {
+
+    private final static Logger logger = LoggerFactory.getLogger(Random.class);
+
+    private final static String dictionary = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789";
+
+    public static SecureRandom getSHA1PRNG() {
+        return getSecureRandom("SHA1PRNG");
+    }
+
+    private static SecureRandom getSecureRandom(String algorithm) {
+        try {
+            return SecureRandom.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            logger.error(e.getMessage(), e);
+            throw new AssertionError(e);
+        }
+    }
+
+    public static char[] getRandomString(int size) {
+        char[] randomString = new char[size];
+        for (int i = 0; i < size; i++) {
+            int randomNum = ThreadLocalRandom.current().nextInt(0, dictionary.length());
+            randomString[i] = dictionary.charAt(randomNum);
+        }
+        return randomString;
+    }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/CustomAutoconfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/CustomAutoconfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.config;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * @author amohan
+ */
+@Configuration
+public class CustomAutoconfiguration {
+
+  @Profile("db")
+  @Configuration
+  @EnableAutoConfiguration
+  public class DbAutoconfiguration {
+
+  }
+
+  @Profile("!db")
+  @Configuration
+  @EnableAutoConfiguration(exclude = {
+      DataSourceAutoConfiguration.class,
+      DataSourceTransactionManagerAutoConfiguration.class,
+      HibernateJpaAutoConfiguration.class})
+  public class NoDbAutoconfiguration {
+
+  }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/EncryptionKeyConfig.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/EncryptionKeyConfig.java
@@ -1,0 +1,45 @@
+package eu.elixir.ega.ebi.keyproviderservice.config;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Profile("db")
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(entityManagerFactoryRef = "keyEntityManagerFactory",
+    transactionManagerRef = "keyTransactionManager", basePackages = {"eu.elixir.ega.ebi.keyproviderservice.domain.key.repository"})
+public class EncryptionKeyConfig {
+
+  @Bean(name = "keyDataSource")
+  @ConfigurationProperties(prefix = "spring.secondDatasource")
+  public DataSource dataSource() {
+    return DataSourceBuilder.create().build();
+  }
+
+  @Bean(name = "keyEntityManagerFactory")
+  public LocalContainerEntityManagerFactoryBean keyEntityManagerFactory(
+      EntityManagerFactoryBuilder builder, @Qualifier("keyDataSource") DataSource dataSource) {
+    return builder.dataSource(dataSource).packages("eu.elixir.ega.ebi.keyproviderservice.domain.key.entity").persistenceUnit("encryptionKey")
+        .build();
+  }
+
+  @Bean(name = "keyTransactionManager")
+  public PlatformTransactionManager keyTransactionManager(
+      @Qualifier("keyEntityManagerFactory") EntityManagerFactory keyEntityManagerFactory) {
+    return new JpaTransactionManager(keyEntityManagerFactory);
+  }
+
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/FileKeyConfig.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/FileKeyConfig.java
@@ -1,0 +1,48 @@
+package eu.elixir.ega.ebi.keyproviderservice.config;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Profile("db")
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(entityManagerFactoryRef = "entityManagerFactory",
+    basePackages = {"eu.elixir.ega.ebi.keyproviderservice.domain.file.repository"})
+public class FileKeyConfig {
+
+  @Primary
+  @Bean(name = "dataSource")
+  @ConfigurationProperties(prefix = "spring.datasource")
+  public DataSource dataSource() {
+    return DataSourceBuilder.create().build();
+  }
+
+  @Primary
+  @Bean(name = "entityManagerFactory")
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+      EntityManagerFactoryBuilder builder, @Qualifier("dataSource") DataSource dataSource) {
+    return builder.dataSource(dataSource).packages("eu.elixir.ega.ebi.keyproviderservice.domain.file.entity").persistenceUnit("fileKey")
+        .build();
+  }
+
+  @Primary
+  @Bean(name = "transactionManager")
+  public PlatformTransactionManager transactionManager(
+      @Qualifier("entityManagerFactory") EntityManagerFactory entityManagerFactory) {
+    return new JpaTransactionManager(entityManagerFactory);
+  }
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/MyConfiguration.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/config/MyConfiguration.java
@@ -15,10 +15,18 @@
  */
 package eu.elixir.ega.ebi.keyproviderservice.config;
 
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+
+import com.google.common.cache.CacheBuilder;
 
 /**
  * @author asenf
@@ -49,6 +57,20 @@ public class MyConfiguration {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+    
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        GuavaCache byFileId = new GuavaCache("byId", CacheBuilder.newBuilder()
+                .expireAfterAccess(24, TimeUnit.HOURS)
+                .build());
+        GuavaCache byFileKeyId = new GuavaCache("byFileKeyId", CacheBuilder.newBuilder()
+                .expireAfterAccess(24, TimeUnit.HOURS)
+                .build());
+
+        simpleCacheManager.setCaches(Arrays.asList(byFileId, byFileKeyId));
+        return simpleCacheManager;
     }
 
 }

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/file/entity/FileKey.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/file/entity/FileKey.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.domain.file.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author amohan
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Entity
+@Table(name = "file_key")
+public class FileKey implements Serializable {
+
+    @Id
+    @Size(max = 128)
+    @Column(name = "file_id", insertable = false, updatable = false, length = 128)
+    private String fileId;
+
+    @Column(name = "encryption_key_id", insertable = false, updatable = false)
+    private long encryptionKeyId;
+
+    @Size(max = 256)
+    @Column(name = "encryption_algorithm", insertable = false, updatable = false, length = 256)
+    private String encryptionAlgorithm;
+
+    @Override
+    public String toString() {
+        return "FileKey [fileId=" + fileId + ", encryptionKeyId=" + encryptionKeyId + ", encryptionAlgorithm="
+                + encryptionAlgorithm + "]";
+    }
+    
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/file/repository/FileKeyRepository.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/file/repository/FileKeyRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.domain.file.repository;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import eu.elixir.ega.ebi.keyproviderservice.domain.file.entity.FileKey;
+
+/**
+ * @author amohan
+ */
+public interface FileKeyRepository extends CrudRepository<FileKey, String> {
+
+    @Cacheable(cacheNames = "byFileKeyId")
+    Iterable<FileKey> findByFileId(@Param("fileId") String fileId);
+    
+}

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/entity/EncryptionKey.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/entity/EncryptionKey.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.elixir.ega.ebi.keyproviderservice.domain.entity;
+package eu.elixir.ega.ebi.keyproviderservice.domain.key.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,6 +33,7 @@ import java.io.Serializable;
 @Setter
 @Getter
 @Entity
+@Table(name = "encryption_key")
 public class EncryptionKey implements Serializable {
 
     @Id

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/repository/EncryptionKeyRepository.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/repository/EncryptionKeyRepository.java
@@ -18,7 +18,6 @@ package eu.elixir.ega.ebi.keyproviderservice.domain.key.repository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import eu.elixir.ega.ebi.keyproviderservice.domain.key.entity.EncryptionKey;
 

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/repository/EncryptionKeyRepository.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/domain/key/repository/EncryptionKeyRepository.java
@@ -13,20 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.elixir.ega.ebi.keyproviderservice.domain.repository;
+package eu.elixir.ega.ebi.keyproviderservice.domain.key.repository;
 
-import eu.elixir.ega.ebi.keyproviderservice.domain.entity.EncryptionKey;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import eu.elixir.ega.ebi.keyproviderservice.domain.key.entity.EncryptionKey;
 
 /**
  * @author asenf
  */
-public interface EncryptionKeyRepository extends CrudRepository<EncryptionKey, Integer> {
+public interface EncryptionKeyRepository extends CrudRepository<EncryptionKey, Long> {
 
     @Cacheable(cacheNames = "byId")
-    EncryptionKey findById(@Param("id") String id);
+    EncryptionKey findById(@Param("id") Long id);
 
 }
  

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
@@ -56,6 +56,9 @@ public class KeyServiceImpl implements KeyService {
 
     @Autowired
     private FileKeyRepository fileKeyRepository;
+    
+    @Autowired
+    private AesCtr256Ega aesCtr256Ega;
 
     @Value("${ega.key.dbPasswordDecryptKey}")
     private String dbPasswordDecryptKey;
@@ -73,7 +76,7 @@ public class KeyServiceImpl implements KeyService {
                 EncryptionKey encryptionKey = encryptionKeyRepository.findById(fileKey.getEncryptionKeyId());
 
                 ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(encryptionKey.getEncryptionKey()));
-                final InputStream decrypt = new AesCtr256Ega().decrypt(inputStream, dbPasswordDecryptKey.toCharArray());
+                final InputStream decrypt = aesCtr256Ega.decrypt(inputStream, dbPasswordDecryptKey.toCharArray());
                 byte[] buffer = new byte[1024];
                 int totalRead = 0;
                 int read;

--- a/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
+++ b/ega-data-api-key/src/main/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImpl.java
@@ -16,9 +16,12 @@
 package eu.elixir.ega.ebi.keyproviderservice.service.internal;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+
 import eu.elixir.ega.ebi.keyproviderservice.config.MyCipherConfig;
-import eu.elixir.ega.ebi.keyproviderservice.domain.entity.EncryptionKey;
-import eu.elixir.ega.ebi.keyproviderservice.domain.repository.EncryptionKeyRepository;
+import eu.elixir.ega.ebi.keyproviderservice.domain.file.entity.FileKey;
+import eu.elixir.ega.ebi.keyproviderservice.domain.file.repository.FileKeyRepository;
+import eu.elixir.ega.ebi.keyproviderservice.domain.key.entity.EncryptionKey;
+import eu.elixir.ega.ebi.keyproviderservice.domain.key.repository.EncryptionKeyRepository;
 import eu.elixir.ega.ebi.keyproviderservice.dto.KeyPath;
 import eu.elixir.ega.ebi.keyproviderservice.service.KeyService;
 import org.bouncycastle.openpgp.PGPPrivateKey;
@@ -29,6 +32,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -45,12 +50,21 @@ public class KeyServiceImpl implements KeyService {
     @Autowired
     private EncryptionKeyRepository encryptionKeyRepository; // Per-File AES Keys
 
+    @Autowired
+    private FileKeyRepository fileKeyRepository;
+
     @Override
     @HystrixCommand
     @ResponseBody
     public String getFileKey(String id) {
-        EncryptionKey findById = encryptionKeyRepository.findById(id);
-        return findById.getEncryptionKey();
+        Iterable<FileKey> fileKeys = fileKeyRepository.findByFileId(id);
+
+        if (fileKeys.iterator().hasNext()) {
+            FileKey fileKey = fileKeys.iterator().next();
+            EncryptionKey findById = encryptionKeyRepository.findById(fileKey.getEncryptionKeyId());
+            return findById.getEncryptionKey();
+        } 
+        return null;
     }
 
     @Override

--- a/ega-data-api-key/src/main/resources/EncryptionKey.sql
+++ b/ega-data-api-key/src/main/resources/EncryptionKey.sql
@@ -19,7 +19,7 @@
  */
 
 CREATE TABLE encryption_key (
-	encryption_key_id bigserial NOT NULL,
+	encryption_key_id int8 NOT NULL,
 	alias varchar(128) NOT NULL,
-	encryption_key text NOT NULL,
+	encryption_key text NOT NULL
 ) ;

--- a/ega-data-api-key/src/main/resources/FileKey.sql
+++ b/ega-data-api-key/src/main/resources/FileKey.sql
@@ -1,0 +1,28 @@
+/* 
+ * Copyright 2017 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Author:  asenf
+ * Created: 17-Feb-2017
+ */
+
+CREATE TABLE dev_ega_file.file_key (
+	file_id  varchar(128) NULL,
+	encryption_key_id int8 NULL,
+    encryption_algorithm varchar(128) NULL
+)
+WITH (
+	OIDS=FALSE
+);

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/SampleTestConfiguration.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/SampleTestConfiguration.java
@@ -1,0 +1,8 @@
+package eu.elixir.ega.ebi.keyproviderservice;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleTestConfiguration {
+
+}

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/AesCtrEgaTest.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/aesdecryption/AesCtrEgaTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 ELIXIR EGA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.elixir.ega.ebi.keyproviderservice.aesdecryption;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class AesCtrEgaTest {
+
+    @Test
+    public void testCipEncryption() throws IOException {
+        final byte[] data = "test file.".getBytes();
+        final char[] password = "test".toCharArray();
+        doEncrypt(data, password);
+
+    }
+
+    private byte[] doEncrypt(byte[] data, char[] password) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputStream stream = new AesCtr256Ega().encrypt(password, baos);
+        stream.write(data);
+        byte[] encryptedData = baos.toByteArray();
+        assertEquals(data.length + 16, encryptedData.length);
+        return encryptedData;
+    }
+
+    @Test
+    public void testCipDecryption() throws IOException {
+        final String message = "test file.";
+        final byte[] data = message.getBytes();
+        final char[] password = "test".toCharArray();
+        final byte[] encryptedMessage = doEncrypt(data, password);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(encryptedMessage);
+        final InputStream decrypt = new AesCtr256Ega().decrypt(inputStream, password);
+        byte[] buffer = new byte[16];
+        int totalRead = 0;
+        int read;
+        while ((read = decrypt.read(buffer)) != -1) {
+            totalRead += read;
+        }
+        assertEquals(message.length(), totalRead);
+        assertEquals(message, new String(buffer, 0, totalRead));
+    }
+
+}

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,8 +37,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import eu.elixir.ega.ebi.keyproviderservice.config.MyCipherConfig;
-import eu.elixir.ega.ebi.keyproviderservice.domain.entity.EncryptionKey;
-import eu.elixir.ega.ebi.keyproviderservice.domain.repository.EncryptionKeyRepository;
+import eu.elixir.ega.ebi.keyproviderservice.domain.file.entity.FileKey;
+import eu.elixir.ega.ebi.keyproviderservice.domain.file.repository.FileKeyRepository;
+import eu.elixir.ega.ebi.keyproviderservice.domain.key.entity.EncryptionKey;
+import eu.elixir.ega.ebi.keyproviderservice.domain.key.repository.EncryptionKeyRepository;
 import eu.elixir.ega.ebi.keyproviderservice.dto.KeyPath;
 import eu.elixir.ega.ebi.keyproviderservice.service.KeyService;
 
@@ -65,6 +68,9 @@ public final class KeyServiceImplTest {
 
     @MockBean
     private EncryptionKeyRepository encryptionKeyRepository;
+    
+    @MockBean
+    private FileKeyRepository fileKeyRepository;
 
     /**
      * Test class for {@link KeyServiceImpl#getFileKey(String)}. Verify the
@@ -72,8 +78,11 @@ public final class KeyServiceImplTest {
      */
     @Test
     public void testGetFileKey() {
-        final EncryptionKey fileKey = new EncryptionKey(100l, "alias", ENCRYPTION_KEY);
-        when(encryptionKeyRepository.findById(ID)).thenReturn(fileKey);
+         FileKey filekey = new FileKey(ID, 200l, "encryptionAlgorithm");
+        final EncryptionKey encryptionKey = new EncryptionKey(200l, "alias", ENCRYPTION_KEY);
+        
+        when(encryptionKeyRepository.findById(200l)).thenReturn(encryptionKey);
+        when(fileKeyRepository.findByFileId(ID)).thenReturn(Arrays.asList(filekey));
         assertThat(keyService.getFileKey(ID), equalTo(ENCRYPTION_KEY));
     }
 

--- a/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
+++ b/ega-data-api-key/src/test/java/eu/elixir/ega/ebi/keyproviderservice/service/internal/KeyServiceImplTest.java
@@ -18,9 +18,13 @@ package eu.elixir.ega.ebi.keyproviderservice.service.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,6 +40,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import eu.elixir.ega.ebi.keyproviderservice.aesdecryption.AesCtr256Ega;
 import eu.elixir.ega.ebi.keyproviderservice.config.MyCipherConfig;
 import eu.elixir.ega.ebi.keyproviderservice.domain.file.entity.FileKey;
 import eu.elixir.ega.ebi.keyproviderservice.domain.file.repository.FileKeyRepository;
@@ -55,7 +60,8 @@ public final class KeyServiceImplTest {
 
     private final String ID = "id";
     private final long KEY_ID = 1000l;
-    private final String ENCRYPTION_KEY = "encryptionKey";
+    private final String ENCRYPTION_KEY = "R6MBpz0ynOMwpceOIzornRNZ1Utp8ByQwumb";
+    private final String ACTUAL_KEY_VALUE = "actualKeyValue";
     private final String PUBLIC_KEY = "publicKey";
     private final String ASCII_ARMOURED_KEY = "AsciiArmouredKey";
     private final String KEY_TYPE = "keyType";
@@ -70,20 +76,26 @@ public final class KeyServiceImplTest {
     private EncryptionKeyRepository encryptionKeyRepository;
     
     @MockBean
+    private AesCtr256Ega aesCtr256Ega;
+    
+    @MockBean
     private FileKeyRepository fileKeyRepository;
 
     /**
      * Test class for {@link KeyServiceImpl#getFileKey(String)}. Verify the
      * EncryptionKey.
+     * @throws IOException 
      */
     @Test
-    public void testGetFileKey() {
+    public void testGetFileKey() throws IOException {
          FileKey filekey = new FileKey(ID, 200l, "encryptionAlgorithm");
         final EncryptionKey encryptionKey = new EncryptionKey(200l, "alias", ENCRYPTION_KEY);
-        
+        final InputStream inputStream = new ByteArrayInputStream(ACTUAL_KEY_VALUE.getBytes());
+
+        when(aesCtr256Ega.decrypt(any(), any())).thenReturn(inputStream);
         when(encryptionKeyRepository.findById(200l)).thenReturn(encryptionKey);
         when(fileKeyRepository.findByFileId(ID)).thenReturn(Arrays.asList(filekey));
-        assertThat(keyService.getFileKey(ID), equalTo(ENCRYPTION_KEY));
+        assertThat(keyService.getFileKey(ID), equalTo(ACTUAL_KEY_VALUE));
     }
 
     /**

--- a/ega-data-api-netflix/ega-data-api-config/config-files/keyserver.properties
+++ b/ega-data-api-netflix/ega-data-api-config/config-files/keyserver.properties
@@ -9,11 +9,17 @@ ega.keypass.path=
 ega.sharedpass.path=
 ega.publickey.url=
 ega.legacy.path=
+ega.key.dbPasswordDecryptKey=
 
-## JPA - PostgreSQL compatible datasource
-spring.datasource.url= ${DB_URL}
+##eg jdbc-url = jdbc:postgresql://postgres.default.svc.cluster.local:5432/egapro?currentSchema=pea_beta
+spring.datasource.jdbc-url= ${DB_URL}
 spring.datasource.username= ${DB_USERNAME}
 spring.datasource.password= ${DB_PASSWORD}
+
+##eg jdbc-url = jdbc:postgresql://postgres.default.svc.cluster.local:5432/egapro?currentSchema=encryption_key_test
+spring.secondDatasource.jdbc-url= ${DB_URL2}
+spring.secondDatasource.username= ${DB_USERNAME2}
+spring.secondDatasource.password= ${DB_PASSWORD2}
 
 ## DataSource common settings
 # Keep the connection alive if idle for a long time (needed in production)


### PR DESCRIPTION
The logic has changed for profile spring.profiles.active=db to fetch the key from the database. It requires 2 datasource:
1. The first datasource has a file_key table. It stores the mapping of FileId to KeyId 
2. The Second datasource has an encryption_key table. It stores the mapping of KeyId to the actual key.

The db actual key is encrypted so to decrypt it we use AesCtr256Ega class decrypt method and pass the db key + password decrypt key.