### PR TITLE
New env vars in application YAML

### DIFF
--- a/ega-data-api-dataedge/src/main/resources/application.yml
+++ b/ega-data-api-dataedge/src/main/resources/application.yml
@@ -2,6 +2,12 @@ spring.profiles: no-oss
 
 eureka.client.enabled: false
 
+# Used when a custom token is generated and we have an ASCII encoded key
+security.oauth2.resource.jwt.key-value: ${JWTKEY}
+
+# Format should be: jdbc:postgresql://<ip_or_service>:<port>/<db_name>
+spring.datasource.url: ${DB_URL}
+
 FILEDATABASE:
   listOfServers: ${FILEDATABASE_SERVERS:filedatabase}
 

--- a/ega-data-api-filedatabase/src/main/resources/application.yml
+++ b/ega-data-api-filedatabase/src/main/resources/application.yml
@@ -2,4 +2,19 @@ spring.profiles: no-oss
 
 eureka.client.enabled: false
 
+# By default when integrating with LocaEGA we will use schema `local_ega`
+spring.jpa.properties.hibernate.default_schema: ${DB_SCHEMA:local_ega}
+
+spring.datasource.driverClassName: org.postgresql.Driver
+
+#spring.jpa.show-sql: true
+
+# Format should be: jdbc:postgresql://<ip_or_service>:<port>/<db_name>
+spring.datasource.url: ${DB_URL}
+
+spring.datasource.username: ${DB_USERNAME}
+
+spring.datasource.password: ${DB_PASSWORD}
+
+
 hystrix.command.default.execution.timeout.enabled: false


### PR DESCRIPTION
Fixes: #89 by adding new environment variables to `application.yml` configuration.
These environment variables are the minimum required variables when deploying the solution with the `no-oss` profile.