### PR TITLE
Add Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Use this to report a new bug
+
+---
+
+### Expected Behavior
+<!--- Tell us what should happen -->
+
+### Current Behavior
+<!--- Tell us what happens instead of the expected behaviour -->
+
+### Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+### Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+### Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+<!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+
+---
+
+### Description
+<!-- What use case are you trying to solve with this feature -->
+
+### Proposed solution
+<!-- A clear and concise description of what you want to happen -->
+
+### Definition of Done
+<!-- How to know this is implemented. Preferably one short sentence -->

--- a/.github/ISSUE_TEMPLATE/new-sprint-task.md
+++ b/.github/ISSUE_TEMPLATE/new-sprint-task.md
@@ -1,0 +1,14 @@
+---
+name: Sprint Task
+about: Use when creating a new task in a sprint
+
+---
+
+### Description
+<!-- What are you working on -->
+
+### Definition of Done
+<!-- How to know when the task is done. -->
+
+### How to test
+<!-- How can someone else verify the task, can be test-suite or something else -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!-- Lines like this one are comments and will not be shown in the final output. -->
+<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
+<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
+
+### Describe the pull request:
+<!-- Replace [ ] with [x] to select options. -->
+- [ ] Bug fix
+- [ ] Functional change
+- [ ] New feature
+- [ ] Code cleanup
+- [ ] Build system change
+- [ ] Documentation change
+- [ ] Language translation
+
+### Pull request long description:
+<!-- Describe your pull request in detail. -->
+
+### Changes made:
+<!-- Enumerate the changes with 1), 2), 3) etc. -->
+<!-- Ensure the test cases are updated if needed. -->
+
+### Related issues:
+<!-- Reference issues with #<issue-num>. -->
+<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
+
+### Additional information:
+<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
+
+### Release note:
+<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
+<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
+
+### Documentation change:
+<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
+<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
+<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
+
+### Mentions:
+<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->


### PR DESCRIPTION
In order to standardise the way we submit issues and Pull Requests, I propose we use the same structure as in LocalEGA. This could be considered as part of this issue https://github.com/EGA-archive/LocalEGA/issues/31 that we have in the current sprint.