### PR TITLE
RES uses the proper endpoints for keyserver

### DIFF
--- a/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/KeyServiceImpl.java
+++ b/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/KeyServiceImpl.java
@@ -63,7 +63,7 @@ public class KeyServiceImpl implements KeyService {
     @Override
     @HystrixCommand
     public String getPublicKey(String id) {
-        return restTemplate.getForEntity(KEYS_SERVICE + "/retrieve/{keyId}/public/{keyType}", String.class, id, "email").getBody();
+        return restTemplate.getForEntity(KEYS_SERVICE + "/keys/retrieve/{keyId}/public", String.class, id).getBody();
     }
 
     /**
@@ -75,7 +75,7 @@ public class KeyServiceImpl implements KeyService {
     @Override
     @HystrixCommand
     public String getPrivateKey(String id) {
-        return restTemplate.getForEntity(KEYS_SERVICE + "/retrieve/{keyId}/private/key", String.class, id).getBody();
+        return restTemplate.getForEntity(KEYS_SERVICE + "/keys/retrieve/{keyId}/private/key", String.class, id).getBody();
     }
 
 }

--- a/ega-data-api-res/src/test/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/KeyServiceImplTest.java
+++ b/ega-data-api-res/src/test/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/KeyServiceImplTest.java
@@ -97,7 +97,7 @@ public class KeyServiceImplTest {
     public void testGetPublicKey() {
         final ResponseEntity<String> mockResponseEntity = mock(ResponseEntity.class);
         final String keyMock = "key";
-        when(restTemplate.getForEntity(KEYS_SERVICE + "/retrieve/{keyId}/public/{keyType}", String.class, "test@elixir.org", "email"))
+        when(restTemplate.getForEntity(KEYS_SERVICE + "/keys/retrieve/{keyId}/public", String.class, "test@elixir.org"))
                 .thenReturn(mockResponseEntity);
         when(mockResponseEntity.getBody()).thenReturn(keyMock);
 
@@ -114,7 +114,7 @@ public class KeyServiceImplTest {
     public void testGetPrivateKey() {
         final ResponseEntity<String> mockResponseEntity = mock(ResponseEntity.class);
         final String keyMock = "key";
-        when(restTemplate.getForEntity(KEYS_SERVICE + "/retrieve/{keyId}/private/key", String.class, "id"))
+        when(restTemplate.getForEntity(KEYS_SERVICE + "/keys/retrieve/{keyId}/private/key", String.class, "id"))
                 .thenReturn(mockResponseEntity);
         when(mockResponseEntity.getBody()).thenReturn(keyMock);
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
It seems that the endpoints RES was calling for keyserver were not ok when retrieving the Public and Private keys. 
e.g. a few lines above RES was using `KEYS_SERVICE + "/keys/retrieve/{keyId}/private/path"`
while the `getPublicKey` was using `KEYS_SERVICE + "/retrieve/{keyId}/public/{keyType}`, meaning based on the `KEYS_SERVICE` address the endpoints were not ok - this issue was addressed.

Also `getPublicKey` seems to be used only by crypt4gh in `LocalEGAServiceImpl`:
``` 
case CRYPT4GH:
       return new Crypt4GHOutputStream(outputStream, keyService.getPublicKey(targetKey));
```

### Changes made:
1. keyserver endpoints are uniform
2. updated unit tests

### Related issues:
Fixes #92 

### Mentions:
@anandmohan777 and @omllobet I am not sure how to use the integration tests to test this, could you provide some guidance. 