### PR TITLE
Used @EnableAsync & @async to write asynchronously the download logs 

### DIFF
--- a/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/config/MyConfiguration.java
+++ b/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/config/MyConfiguration.java
@@ -15,10 +15,10 @@
  */
 package eu.elixir.ega.ebi.dataedge.config;
 
-import com.google.common.cache.CacheBuilder;
-import eu.elixir.ega.ebi.shared.config.ClientUserIpInterceptor;
-import eu.elixir.ega.ebi.shared.dto.MyExternalConfig;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -34,15 +34,17 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
+
+import com.google.common.cache.CacheBuilder;
+
+import eu.elixir.ega.ebi.shared.config.ClientUserIpInterceptor;
+import eu.elixir.ega.ebi.shared.dto.MyExternalConfig;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author asenf
@@ -51,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 @EnableCaching
 @EnableRetry
 @EnableEurekaClient
+@EnableAsync
 public class MyConfiguration {
 
     @Value("${ega.ega.external.url}")
@@ -82,12 +85,6 @@ public class MyConfiguration {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.setInterceptors(Collections.singletonList(clientUserIpInterceptor()));
         return restTemplate;
-    }
-
-    @Bean
-    @LoadBalanced
-    public AsyncRestTemplate asyncRestTemplate() {
-        return new AsyncRestTemplate();
     }
 
     @Bean

--- a/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
+++ b/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
@@ -33,8 +33,6 @@ import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
 import eu.elixir.ega.ebi.shared.dto.EventEntry;
 import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
 
-//import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-
 /**
  * @author asenf
  */
@@ -45,9 +43,11 @@ public class RemoteDownloaderLogServiceImpl extends
 
     @Autowired
     private RestTemplate restTemplate;
-
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
     @Override
-    //@HystrixCommand
     @Async
     public void logDownload(DownloadEntry downloadEntry) {
 
@@ -57,15 +57,15 @@ public class RemoteDownloaderLogServiceImpl extends
         // Jackson ObjectMapper to convert requestBody to JSON
         String json = null;
         try {
-            json = new ObjectMapper().writeValueAsString(downloadEntry);
-        } catch (JsonProcessingException ignored) {
+            json = objectMapper.writeValueAsString(downloadEntry);
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new RuntimeException(jsonProcessingException);
         }
 
         restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", new HttpEntity<>(json, headers), String.class);
     }
 
     @Override
-    //@HystrixCommand
     @Async
     public void logEvent(EventEntry eventEntry) {
 
@@ -75,8 +75,9 @@ public class RemoteDownloaderLogServiceImpl extends
         // Jackson ObjectMapper to convert requestBody to JSON
         String json = null;
         try {
-            json = new ObjectMapper().writeValueAsString(eventEntry);
-        } catch (JsonProcessingException ignored) {
+            json = objectMapper.writeValueAsString(eventEntry);
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new RuntimeException(jsonProcessingException);
         }
 
         restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", new HttpEntity<>(json, headers), String.class);

--- a/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
+++ b/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
@@ -15,25 +15,23 @@
  */
 package eu.elixir.ega.ebi.shared.service.internal;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
-import eu.elixir.ega.ebi.shared.dto.EventEntry;
-import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
-import eu.elixir.ega.ebi.shared.service.internal.AbstractDownloaderLogService;
+import static eu.elixir.ega.ebi.shared.Constants.FILEDATABASE_SERVICE;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.ListenableFutureCallback;
-import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 
-import static eu.elixir.ega.ebi.shared.Constants.FILEDATABASE_SERVICE;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
+import eu.elixir.ega.ebi.shared.dto.EventEntry;
+import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
 
 //import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
@@ -46,13 +44,11 @@ public class RemoteDownloaderLogServiceImpl extends
     AbstractDownloaderLogService implements DownloaderLogService {
 
     @Autowired
-    private AsyncRestTemplate restTemplate;
-
-    @Autowired
-    private RestTemplate syncRestTemplate;
+    private RestTemplate restTemplate;
 
     @Override
     //@HystrixCommand
+    @Async
     public void logDownload(DownloadEntry downloadEntry) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -65,33 +61,12 @@ public class RemoteDownloaderLogServiceImpl extends
         } catch (JsonProcessingException ignored) {
         }
 
-        HttpEntity<String> entity = new HttpEntity<>(json, headers);
-        //HttpEntity entity = new HttpEntity("parameters", headers);
-
-        ListenableFuture<ResponseEntity<String>> futureEntity;
-        futureEntity = restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", entity, String.class);
-
-        futureEntity
-                .addCallback(new ListenableFutureCallback<ResponseEntity>() {
-                    @Override
-                    public void onSuccess(ResponseEntity result) {
-                        System.out.println(result.getBody());
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        System.out.println("LOG FAILURE: " + t.toString());
-                    }
-                });
-
-        // Old Synchronous Call
-        //syncRestTemplate.postForObject(SERVICE_URL + "/log/download/", downloadEntry, Void.class);
-        //restTemplate.ppostForEntity(SERVICE_URL + "/log/download/", downloadEntry, Void.class);
-
+        restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", new HttpEntity<>(json, headers), String.class);
     }
 
     @Override
     //@HystrixCommand
+    @Async
     public void logEvent(EventEntry eventEntry) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -104,26 +79,7 @@ public class RemoteDownloaderLogServiceImpl extends
         } catch (JsonProcessingException ignored) {
         }
 
-        HttpEntity<String> entity = new HttpEntity<>(json, headers);
-        //HttpEntity entity = new HttpEntity("parameters", headers);
-
-        ListenableFuture<ResponseEntity<String>> futureEntity;
-        futureEntity = restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", entity, String.class);
-
-        futureEntity
-                .addCallback(new ListenableFutureCallback<ResponseEntity>() {
-                    @Override
-                    public void onSuccess(ResponseEntity result) {
-                        System.out.println(result.getBody());
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                    }
-                });
-
-        // Old Synchronous Call
-        //restTemplate.postForObject(SERVICE_URL + "/log/event/", eventEntry, Void.class);
+        restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", new HttpEntity<>(json, headers), String.class);
     }
 
 }

--- a/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteDownloaderLogServiceImplTest.java
+++ b/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteDownloaderLogServiceImplTest.java
@@ -37,6 +37,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
 import eu.elixir.ega.ebi.shared.dto.EventEntry;
 import eu.elixir.ega.ebi.shared.service.internal.RemoteDownloaderLogServiceImpl;
@@ -56,6 +58,9 @@ public class RemoteDownloaderLogServiceImplTest {
 
     @Mock
     private RestTemplate restTemplate;
+    
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Before
     public void initMocks() throws Exception {

--- a/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteDownloaderLogServiceImplTest.java
+++ b/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteDownloaderLogServiceImplTest.java
@@ -15,10 +15,16 @@
  */
 package eu.elixir.ega.ebi.dataedge.service.internal;
 
-import com.netflix.appinfo.InstanceInfo;
-import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
-import eu.elixir.ega.ebi.shared.dto.EventEntry;
-import eu.elixir.ega.ebi.shared.service.internal.RemoteDownloaderLogServiceImpl;
+import static eu.elixir.ega.ebi.shared.Constants.FILEDATABASE_SERVICE;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.net.URI;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,17 +35,11 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
-
-import static eu.elixir.ega.ebi.shared.Constants.FILEDATABASE_SERVICE;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.*;
+import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
+import eu.elixir.ega.ebi.shared.dto.EventEntry;
+import eu.elixir.ega.ebi.shared.service.internal.RemoteDownloaderLogServiceImpl;
 
 /**
  * Test class for {@link RemoteDownloaderLogServiceImpl}.
@@ -55,22 +55,18 @@ public class RemoteDownloaderLogServiceImplTest {
     private RemoteDownloaderLogServiceImpl remoteDownloaderLogServiceImpl;
 
     @Mock
-    private AsyncRestTemplate restTemplate;
-
-    @Mock
-    private RestTemplate syncRestTemplate;
+    private RestTemplate restTemplate;
 
     @Before
     public void initMocks() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        final InstanceInfo instance = mock(InstanceInfo.class);
         final URI uriMock = mock(URI.class);
-        @SuppressWarnings("unchecked") final ListenableFuture<ResponseEntity<String>> futureEntityMock = mock(ListenableFuture.class);
+        final ResponseEntity<String> responseString = mock(ResponseEntity.class);
 
         whenNew(URI.class).withAnyArguments().thenReturn(uriMock);
-        when(restTemplate.postForEntity(eq(FILEDATABASE_SERVICE + "/log/download/"), any(), eq(String.class))).thenReturn(futureEntityMock);
-        when(restTemplate.postForEntity(eq(FILEDATABASE_SERVICE + "/log/event/"), any(), eq(String.class))).thenReturn(futureEntityMock);
+        when(restTemplate.postForEntity(eq(FILEDATABASE_SERVICE + "/log/download/"), any(), eq(String.class))).thenReturn(responseString);
+        when(restTemplate.postForEntity(eq(FILEDATABASE_SERVICE + "/log/event/"), any(), eq(String.class))).thenReturn(responseString);
     }
 
     /**

--- a/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/htsget/config/MyConfiguration.java
+++ b/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/htsget/config/MyConfiguration.java
@@ -15,10 +15,10 @@
  */
 package eu.elixir.ega.ebi.htsget.config;
 
-import com.google.common.cache.CacheBuilder;
-import eu.elixir.ega.ebi.shared.config.ClientUserIpInterceptor;
-import eu.elixir.ega.ebi.shared.dto.MyExternalConfig;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -34,15 +34,17 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
+
+import com.google.common.cache.CacheBuilder;
+
+import eu.elixir.ega.ebi.shared.config.ClientUserIpInterceptor;
+import eu.elixir.ega.ebi.shared.dto.MyExternalConfig;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author asenf
@@ -51,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 @EnableCaching
 @EnableRetry
 @EnableEurekaClient
+@EnableAsync
 public class MyConfiguration {
 
     @Value("${ega.ega.external.url}")
@@ -82,12 +85,6 @@ public class MyConfiguration {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.setInterceptors(Collections.singletonList(clientUserIpInterceptor()));
         return restTemplate;
-    }
-
-    @Bean
-    @LoadBalanced
-    public AsyncRestTemplate asyncRestTemplate() {
-        return new AsyncRestTemplate();
     }
 
     @Bean

--- a/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
+++ b/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
@@ -17,22 +17,21 @@ package eu.elixir.ega.ebi.shared.service.internal;
 
 import static eu.elixir.ega.ebi.shared.Constants.FILEDATABASE_SERVICE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
-import eu.elixir.ega.ebi.shared.dto.EventEntry;
-import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.ListenableFutureCallback;
-import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
+import eu.elixir.ega.ebi.shared.dto.EventEntry;
+import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
 
 //import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
@@ -45,13 +44,11 @@ public class RemoteDownloaderLogServiceImpl extends
     AbstractDownloaderLogService implements DownloaderLogService {
 
     @Autowired
-    private AsyncRestTemplate restTemplate;
-
-    @Autowired
-    private RestTemplate syncRestTemplate;
+    private RestTemplate restTemplate;
 
     @Override
     //@HystrixCommand
+    @Async
     public void logDownload(DownloadEntry downloadEntry) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -64,33 +61,12 @@ public class RemoteDownloaderLogServiceImpl extends
         } catch (JsonProcessingException ignored) {
         }
 
-        HttpEntity<String> entity = new HttpEntity<>(json, headers);
-        //HttpEntity entity = new HttpEntity("parameters", headers);
-
-        ListenableFuture<ResponseEntity<String>> futureEntity;
-        futureEntity = restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", entity, String.class);
-
-        futureEntity
-                .addCallback(new ListenableFutureCallback<ResponseEntity>() {
-                    @Override
-                    public void onSuccess(ResponseEntity result) {
-                        System.out.println(result.getBody());
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        System.out.println("LOG FAILURE: " + t.toString());
-                    }
-                });
-
-        // Old Synchronous Call
-        //syncRestTemplate.postForObject(SERVICE_URL + "/log/download/", downloadEntry, Void.class);
-        //restTemplate.ppostForEntity(SERVICE_URL + "/log/download/", downloadEntry, Void.class);
-
+        restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", new HttpEntity<>(json, headers), String.class);
     }
 
     @Override
     //@HystrixCommand
+    @Async
     public void logEvent(EventEntry eventEntry) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -103,26 +79,7 @@ public class RemoteDownloaderLogServiceImpl extends
         } catch (JsonProcessingException ignored) {
         }
 
-        HttpEntity<String> entity = new HttpEntity<>(json, headers);
-        //HttpEntity entity = new HttpEntity("parameters", headers);
-
-        ListenableFuture<ResponseEntity<String>> futureEntity;
-        futureEntity = restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", entity, String.class);
-
-        futureEntity
-                .addCallback(new ListenableFutureCallback<ResponseEntity>() {
-                    @Override
-                    public void onSuccess(ResponseEntity result) {
-                        System.out.println(result.getBody());
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                    }
-                });
-
-        // Old Synchronous Call
-        //restTemplate.postForObject(SERVICE_URL + "/log/event/", eventEntry, Void.class);
+        restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", new HttpEntity<>(json, headers), String.class);
     }
 
 }

--- a/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
+++ b/ega-data-api-htsget/src/main/java/eu/elixir/ega/ebi/shared/service/internal/RemoteDownloaderLogServiceImpl.java
@@ -33,8 +33,6 @@ import eu.elixir.ega.ebi.shared.dto.DownloadEntry;
 import eu.elixir.ega.ebi.shared.dto.EventEntry;
 import eu.elixir.ega.ebi.shared.service.DownloaderLogService;
 
-//import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-
 /**
  * @author asenf
  */
@@ -46,8 +44,10 @@ public class RemoteDownloaderLogServiceImpl extends
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+    
     @Override
-    //@HystrixCommand
     @Async
     public void logDownload(DownloadEntry downloadEntry) {
 
@@ -57,15 +57,15 @@ public class RemoteDownloaderLogServiceImpl extends
         // Jackson ObjectMapper to convert requestBody to JSON
         String json = null;
         try {
-            json = new ObjectMapper().writeValueAsString(downloadEntry);
-        } catch (JsonProcessingException ignored) {
+            json = objectMapper.writeValueAsString(downloadEntry);
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new RuntimeException(jsonProcessingException);
         }
 
         restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/download/", new HttpEntity<>(json, headers), String.class);
     }
 
     @Override
-    //@HystrixCommand
     @Async
     public void logEvent(EventEntry eventEntry) {
 
@@ -75,8 +75,9 @@ public class RemoteDownloaderLogServiceImpl extends
         // Jackson ObjectMapper to convert requestBody to JSON
         String json = null;
         try {
-            json = new ObjectMapper().writeValueAsString(eventEntry);
-        } catch (JsonProcessingException ignored) {
+            json = objectMapper.writeValueAsString(eventEntry);
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new RuntimeException(jsonProcessingException);
         }
 
         restTemplate.postForEntity(FILEDATABASE_SERVICE + "/log/event/", new HttpEntity<>(json, headers), String.class);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Async doesn't work with Eureka. Throws java.net.UnknownHostException at AsyncRestTemplate.postForEntity(...)

### Changes made:
Used `@EnableAsync`  & `@Async` to write the logs asynchronously and changed AsyncRestTemplate to RestTemplate

### Related issues:
Fixes https://github.com/EGA-archive/ega-data-api/issues/107