### PR TITLE
Update postgres dependency to support scram-sha-256 passwords

### DIFF
--- a/ega-data-api-filedatabase/pom.xml
+++ b/ega-data-api-filedatabase/pom.xml
@@ -65,6 +65,7 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
+			<version>42.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>

--- a/ega-data-api-key/pom.xml
+++ b/ega-data-api-key/pom.xml
@@ -27,6 +27,7 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
+			<version>42.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/ega-data-api-res/pom.xml
+++ b/ega-data-api-res/pom.xml
@@ -82,6 +82,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.2.5</version>
         </dependency>
 
         <!-- EGA-archive -->


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
Update dependency to support scram-sha-256 passwords.

### Changes made:
Updated in Key, FileDatabase and RES

### Related issues:
EGA-archive/LocalEGA#41
