### PR TITLE
Making S3 variables Null by default and solving POSIX

### DIFF
--- a/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/MyConfiguration.java
+++ b/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/MyConfiguration.java
@@ -55,13 +55,13 @@ public class MyConfiguration {
     @Value("${ega.ebi.fire.key}")
     private String fireKey;
 
-    @Value("${ega.ebi.aws.access.key}")
+    @Value("${ega.ebi.aws.access.key:#{null}}")
     private String awsKey;
-    @Value("${ega.ebi.aws.access.secret}")
+    @Value("${ega.ebi.aws.access.secret:#{null}}")
     private String awsSecretKey;
-    @Value("${ega.ebi.aws.endpoint.url}")
+    @Value("${ega.ebi.aws.endpoint.url:#{null}}")
     private String awsEndpointUrl;
-    @Value("${ega.ebi.aws.endpoint.region}")
+    @Value("${ega.ebi.aws.endpoint.region:#{null}}")
     private String awsRegion;
 
     @Value("${service.archive.class}")

--- a/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/LocalEGAServiceImpl.java
+++ b/ega-data-api-res/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/internal/LocalEGAServiceImpl.java
@@ -70,16 +70,16 @@ public class LocalEGAServiceImpl implements ResService {
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
     private static final int MAX_EXPIRATION_TIME = 7 * 24 * 3600;
 
-    @Value("${ega.ebi.aws.endpoint.url}")
+    @Value("${ega.ebi.aws.endpoint.url:#{null}}")
     private String s3URL;
 
     @Value("${ega.ebi.aws.bucket:lega}")
     private String s3Bucket;
 
-    @Value("${ega.ebi.aws.access.key}")
+    @Value("${ega.ebi.aws.access.key:#{null}}")
     private String s3Key;
 
-    @Value("${ega.ebi.aws.access.secret}")
+    @Value("${ega.ebi.aws.access.secret:#{null}}")
     private String s3Secret;
 
     @Autowired


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
The POSIX worked by default with `LocalEGA` profile, but the S3 environment variables needed a `null` value so that the RES service could start.

### Changes made:
1. Made `ega.ebi.aws.*` env vars `null` by default so that service could be started.

### Related issues:
Fixes #73 

### Additional information:
More information on how to make it work are in #73 .
