### PR TITLE
Remove retrytemplate and spring retry as it is not used 

### DIFF
--- a/ega-data-api-dataedge/pom.xml
+++ b/ega-data-api-dataedge/pom.xml
@@ -32,10 +32,6 @@
             <artifactId>spring-cloud-starter-oauth2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/config/MyConfiguration.java
+++ b/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/config/MyConfiguration.java
@@ -30,10 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
 
@@ -51,7 +47,6 @@ import springfox.documentation.spring.web.plugins.Docket;
  */
 @Configuration
 @EnableCaching
-@EnableRetry
 @EnableEurekaClient
 @EnableAsync
 public class MyConfiguration {
@@ -85,22 +80,6 @@ public class MyConfiguration {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.setInterceptors(Collections.singletonList(clientUserIpInterceptor()));
         return restTemplate;
-    }
-
-    @Bean
-    @LoadBalanced
-    public RetryTemplate retryTemplate() {
-        RetryTemplate retryTemplate = new RetryTemplate();
-
-        FixedBackOffPolicy fixedBackOffPolicy = new FixedBackOffPolicy();
-        fixedBackOffPolicy.setBackOffPeriod(2000L);
-        retryTemplate.setBackOffPolicy(fixedBackOffPolicy);
-
-        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-        retryPolicy.setMaxAttempts(4);
-        retryTemplate.setRetryPolicy(retryPolicy);
-
-        return retryTemplate;
     }
 
     @Bean

--- a/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImpl.java
+++ b/ega-data-api-dataedge/src/main/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImpl.java
@@ -51,7 +51,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
@@ -90,9 +89,6 @@ public class RemoteFileServiceImpl implements FileService {
 
     @Autowired
     private RestTemplate restTemplate;
-
-    @Autowired
-    private RetryTemplate retryTemplate;
 
     // Database Repositories/Services
 

--- a/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImplTest.java
+++ b/ega-data-api-dataedge/src/test/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImplTest.java
@@ -46,7 +46,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -93,9 +92,6 @@ public class RemoteFileServiceImplTest {
 
     @Mock
     private RestTemplate restTemplate;
-
-    @Mock
-    private RetryTemplate retryTemplate;
 
     @Mock
     MyExternalConfig externalConfig;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
RetryTemplate was failing and it seems it was not used anywhere when disabled so it was remove completely.

If necessary we will figure out a way to add it back but for now it is removed.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #94 

### Additional information:
Tried different ways to disable it as recommended by spring-boot, however without success so it seems the most efficient way is to remove it.

Extract from @AlexanderSenf email:
> looking “private RetryTemplate retryTemplate;” in DataEdge, we can see it being declared only once (outside of test): in RemoteFileServiceImpl. But it is never used anywhere, (https://github.com/EGA-archive/ega-data-api/search?q=retryTemplate&unscoped_q=retryTemplate) 