### PR TITLE
Remove duplicated dependency

### DIFF
--- a/ega-data-api-res/pom.xml
+++ b/ega-data-api-res/pom.xml
@@ -160,11 +160,6 @@
             <artifactId>minio</artifactId>
             <version>5.0.1</version>
         </dependency>
-        <dependency>
-            <groupId>io.minio</groupId>
-            <artifactId>minio</artifactId>
-            <version>5.0.1</version>
-        </dependency>
 
         <!-- Test -->
         <dependency>


### PR DESCRIPTION
Minio dependency is specified two times. This PR removes one

Fixes a maven build warning.
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation