### PR TITLE
Add entrypoint.sh to support CA injection

### DIFF
--- a/Dockerfile.dataedge
+++ b/Dockerfile.dataedge
@@ -12,4 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/ega-data-api"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 COPY --from=builder ega-data-api-dataedge/target/ega-data-api-dataedge-0.0.1-SNAPSHOT.jar .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["java", "-jar", "ega-data-api-dataedge-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile.filedatabase
+++ b/Dockerfile.filedatabase
@@ -12,4 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/ega-data-api"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 COPY --from=builder ega-data-api-filedatabase/target/ega-data-api-filedatabase-0.0.1-SNAPSHOT.jar .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["java", "-jar", "ega-data-api-filedatabase-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile.htsget
+++ b/Dockerfile.htsget
@@ -12,4 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/ega-data-api"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 COPY --from=builder ega-data-api-htsget/target/ega-data-api-htsget-0.0.1-SNAPSHOT.jar .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["java", "-jar", "ega-data-api-htsget-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile.keyserver
+++ b/Dockerfile.keyserver
@@ -12,4 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/ega-data-api"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 COPY --from=builder ega-data-api-key/target/ega-data-api-key-0.0.1-SNAPSHOT.jar .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["java", "-jar", "ega-data-api-key-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile.res
+++ b/Dockerfile.res
@@ -12,4 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/ega-data-api"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 COPY --from=builder ega-data-api-res/target/ega-data-api-res-0.0.1-SNAPSHOT.jar .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["java", "-jar", "ega-data-api-res-0.0.1-SNAPSHOT.jar"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo "Updating CA certificates..."
+update-ca-certificates
+echo "Done!"
+
+exec "$@"


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
We add `entrypoint.sh` which executes `update-ca-certificates` to apply injected to `/usr/local/share/ca-certificates/` CA certificate.

### Related issues:
https://github.com/EGA-archive/ega-data-api/issues/99

### Additional information:
This is only the first part of https://github.com/EGA-archive/ega-data-api/issues/99 issue.
